### PR TITLE
Fix bash operator in the npm script 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch & nodemon dist",
+    "dev": "tsc --watch && nodemon dist",
     "test": "tsc && mocha dist/**/*.spec.js",
     "lint": "eslint src --ext ts",
     "tsc": "tsc"


### PR DESCRIPTION
## Issue

Has an error in the command of the npm script when run `npm run dev`.

## Main changes

- small fix (ee17496)